### PR TITLE
Convert nc archive to csv archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2] - XXXX-XX-XX
 
+### Added
+
+- Functionality to convert an archive of netCDF files to csv files (util.archive_to_csv)
+
 ### Removed
 
 - No longer accepts public or private outputs. These should be specified in separate "parent" repositories

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -437,6 +437,8 @@ def output_path(network,
     if extra_archive:
         archive_path = archive_suffix(paths.output_path,
                                       extra_archive)
+    else:
+        archive_path = paths.output_path
 
     # Can tweak data_file_path to get the output path
     output_path = data_file_path("", network = network,

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -15,7 +15,7 @@ from agage_archive.data_selection import read_release_schedule, read_data_exclud
     read_data_combination, calibration_scale_default
 from agage_archive.definitions import instrument_type_definition, get_instrument_type, \
     get_instrument_number, instrument_selection_text
-from agage_archive.util import tz_local_to_utc, parse_fortran_format
+from agage_archive.util import tz_local_to_utc, parse_fortran_format, nc_to_csv
 
 
 gcwerks_species = {"c2f6": "pfc-116",

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -1,13 +1,8 @@
 import pandas as pd
-from shutil import rmtree
-from zipfile import ZipFile
-import time
 import traceback
-import os
-import xarray as xr
 
 from agage_archive.config import Paths, open_data_file, data_file_list, data_file_path, \
-    copy_to_archive, output_path
+    copy_to_archive, delete_archive, create_empty_archive
 from agage_archive.data_selection import read_release_schedule, read_data_combination, choose_scale_defaults_file
 from agage_archive.io import combine_datasets, combine_baseline, \
     read_nc, read_baseline, read_ale_gage, read_gcwerks_flask, read_gcms_magnum, \
@@ -15,7 +10,6 @@ from agage_archive.io import combine_datasets, combine_baseline, \
 from agage_archive.formatting import format_species
 from agage_archive.convert import monthly_baseline
 from agage_archive.definitions import instrument_number, instrument_selection_text
-from agage_archive.util import insert_into_archive_name
 
 
 def get_error(e):
@@ -38,65 +32,6 @@ def get_error(e):
 
     error_type = type(e).__name__
     return f"{error_type} in stack: {' / '.join(stack_files_and_lines)}. {str(e)}"
-
-
-def delete_archive(network, archive_suffix=""):
-    """Delete all files in output directory before running
-
-    Args:
-        network (str): Network for output filenames
-    """
-
-    path = Paths(network, errors="ignore")
-
-    try:
-        out_pth, _ = output_path(network, "_", "_", "_",
-                                errors="ignore_inputs")
-    except FileNotFoundError:
-        print(f"Output directory or archive for does not exist, continuing")
-        return
-
-    # Find all files in output directory
-    _, _, files = data_file_list(network=network,
-                                sub_path=path.output_path,
-                                errors="ignore")
-
-    print(f'Deleting all files in {out_pth}')
-
-    # If out_pth is a zip file, delete it
-    if out_pth.suffix == ".zip" and out_pth.exists():
-        out_pth.unlink()
-    else:
-        # For safety that out_pth is in data/network directory
-        if out_pth.parents[1] == path.data and out_pth.parents[0].name == network:
-            pass
-        else:
-            raise ValueError(f"{out_pth} must be in a data/network directory")
-
-        # Delete all files in output directory
-        for f in files:
-            pth = out_pth / f
-            if pth.is_file():
-                pth.unlink()
-            elif pth.is_dir():
-                rmtree(pth)
-
-
-def create_empty_archive(network):
-    """Create an empty output zip file or folders
-
-    Args:
-        network (str): Network for output filenames
-    """
-
-    out_pth, _ = output_path(network, "_", "_", "_",
-                            errors="ignore")
-
-    if out_pth.suffix == ".zip" and not out_pth.exists():
-        with ZipFile(out_pth, "w") as f:
-            pass
-    elif out_pth.is_dir():
-        out_pth.mkdir(parents=True, exist_ok=True)
 
 
 def run_timestamp_checks(ds,

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -15,6 +15,7 @@ from agage_archive.io import combine_datasets, combine_baseline, \
 from agage_archive.formatting import format_species
 from agage_archive.convert import monthly_baseline
 from agage_archive.definitions import instrument_number, instrument_selection_text
+from agage_archive.util import insert_into_archive_name
 
 
 def get_error(e):
@@ -39,7 +40,7 @@ def get_error(e):
     return f"{error_type} in stack: {' / '.join(stack_files_and_lines)}. {str(e)}"
 
 
-def delete_archive(network):
+def delete_archive(network, archive_suffix=""):
     """Delete all files in output directory before running
 
     Args:

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import traceback
+from tqdm import tqdm
 
 from agage_archive.config import Paths, open_data_file, data_file_list, data_file_path, \
     copy_to_archive, delete_archive, create_empty_archive
@@ -423,7 +424,7 @@ def run_combined_instruments(network,
 
     error_log = []
 
-    for site in sites:
+    for site in tqdm(sites):
         result = run_combined_site(site, species, network, baseline, monthly, verbose, resample)
         error_log.extend(result)
 
@@ -518,6 +519,10 @@ def run_all(network,
 
     # Must run combined instruments first
     if combined:
+        print("#########################################")
+        print("#####Processing combined instruments######")
+        print("#########################################")
+
         run_combined_instruments(network,
                                 baseline=baseline, verbose=True,
                                 monthly=monthly, species=species, sites=sites,
@@ -532,8 +537,11 @@ def run_all(network,
     else:
         instruments = instrument_include
 
-    # Processing
-    for instrument in instruments:
+    print("#########################################")
+    print("#####Processing individual instruments######")
+    print("#########################################")
+
+    for instrument in tqdm(instruments):
         if instrument not in instrument_exclude:
             baseline_flag = {True: "git_pollution_flag", False: ""}[baseline]
             run_individual_instrument(network, instrument, 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import yaml
 import json
 
 from agage_archive.config import Paths, data_file_path, \
-    open_data_file, data_file_list, output_path
+    open_data_file, data_file_list, output_path, archive_suffix
 
 
 repo_path = Path(__file__).resolve().parents[1]
@@ -138,3 +138,11 @@ def test_output_path():
     assert out_path == out_path_true
     assert filename == "agage_test-gcms-medusa_thd_cfc-11_testing-v1.nc"
 
+
+def test_archive_suffix():
+    """Test the insert_into_archive_name function with various cases."""
+    assert archive_suffix("archive.zip", "-csv") == "archive-csv.zip"
+    assert archive_suffix("folder/", "-csv") == "folder-csv/"
+    assert archive_suffix("folder", "-csv") == "folder-csv"
+
+    assert archive_suffix(Path("archive.zip"), "-csv").name == Path("archive-csv.zip").name

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ def test_data_file_list():
     # Test that we can list files in a folder
     network, sub_path, files = data_file_list("agage_test", "path_test_files")
     assert network == "agage_test"
-    assert sub_path == "path_test_files/"
+    assert sub_path == "path_test_files"
     assert "test.txt" in files
 
     # Test that we can list files in a zip archive

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ import pandas as pd
 import xarray as xr
 from pathlib import Path
 
-from agage_archive.util import parse_fortran_format, nc_to_csv, insert_into_archive_name
+from agage_archive.util import parse_fortran_format, nc_to_csv
 
 
 def test_parse_fortran_format():
@@ -88,13 +88,4 @@ def test_nc_to_csv():
     assert df["hour"].tolist() == [0, 0, 0, 0, 0], "Hour column does not have the expected data."
     assert df["minute"].tolist() == [0, 0, 0, 0, 0], "Minute column does not have the expected data."
     assert df["second"].tolist() == [0, 0, 0, 0, 0], "Second column does not have the expected data."
-
-
-def test_insert_into_archive_name():
-    """Test the insert_into_archive_name function with various cases."""
-    assert insert_into_archive_name("archive.zip", "-csv") == "archive-csv.zip"
-    assert insert_into_archive_name("folder/", "-csv") == "folder-csv/"
-    assert insert_into_archive_name("folder", "-csv") == "folder-csv"
-
-    assert insert_into_archive_name(Path("archive.zip"), "-csv").name == Path("archive-csv.zip").name
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,8 @@
-from agage_archive.util import parse_fortran_format
+import pandas as pd
+import xarray as xr
+from pathlib import Path
+
+from agage_archive.util import parse_fortran_format, nc_to_csv, insert_into_archive_name
 
 
 def test_parse_fortran_format():
@@ -36,4 +40,61 @@ def test_parse_fortran_format():
     assert column_types[1] == int
     assert column_types[2] == int
     assert column_types[3] == float
+
+
+def test_nc_to_csv():
+    """Test the nc_to_csv function with a sample xarray Dataset."""
+    # Create a sample xarray Dataset
+    times = pd.date_range("2023-01-01", periods=5, freq="D")
+    data = xr.Dataset(
+        {
+            "mf": (["time"], [15.0, 16.5, 14.2, 15.8, 16.0]),
+            "mf_repeatability": (["time"], [30, 45, 50, 55, 60]),
+        },
+        coords={
+            "time": times,
+        },
+    )
+    data.attrs["source"] = "Test Data"
+    data.mf.attrs["units"] = "ppt"
+    data.mf_repeatability.attrs["units"] = "Percent"
+
+    header, df = nc_to_csv(data)
+
+    assert header[0] == "# GLOBAL ATTRIBUTES:"
+
+    assert "source: Test Data" in header[2]
+    assert any(["units: ppt" in line for line in header])
+    wh_mf = [i for i, line in enumerate(header) if "mf:" in line]
+    assert "units: ppt" in header[wh_mf[0] + 1], "Units line for 'mf' not found after 'mf:' line."
+
+    assert any("mf_repeatability:" in line for line in header)
+
+    assert header[-1] == "# DATA:"
+    
+    # Check if the DataFrame has the expected columns
+    expected_columns = ["time", "year", "month", "day", "hour", "minute", "second", "mf", "mf_repeatability"]
+    assert all(col in df.columns for col in expected_columns), "DataFrame does not have the expected columns."
+    # Check if the DataFrame has the expected number of rows
+    assert len(df) == 5, "DataFrame does not have the expected number of rows."
+    # Check if the DataFrame has the expected data
+    assert df["mf"].tolist() == [15.0, 16.5, 14.2, 15.8, 16.0], "DataFrame 'mf' column does not have the expected data."
+    assert df["mf_repeatability"].tolist() == [30, 45, 50, 55, 60], "DataFrame 'mf_repeatability' column does not have the expected data."
+
+    # Check that the year, month, day, hour, minute, second columns are correctly populated
+    assert df["year"].tolist() == [2023, 2023, 2023, 2023, 2023], "Year column does not have the expected data."
+    assert df["month"].tolist() == [1, 1, 1, 1, 1], "Month column does not have the expected data."
+    assert df["day"].tolist() == [1, 2, 3, 4, 5], "Day column does not have the expected data."
+    assert df["hour"].tolist() == [0, 0, 0, 0, 0], "Hour column does not have the expected data."
+    assert df["minute"].tolist() == [0, 0, 0, 0, 0], "Minute column does not have the expected data."
+    assert df["second"].tolist() == [0, 0, 0, 0, 0], "Second column does not have the expected data."
+
+
+def test_insert_into_archive_name():
+    """Test the insert_into_archive_name function with various cases."""
+    assert insert_into_archive_name("archive.zip", "-csv") == "archive-csv.zip"
+    assert insert_into_archive_name("folder/", "-csv") == "folder-csv/"
+    assert insert_into_archive_name("folder", "-csv") == "folder-csv"
+
+    assert insert_into_archive_name(Path("archive.zip"), "-csv").name == Path("archive-csv.zip").name
 


### PR DESCRIPTION
A new function is added: util.archive_to_csv, which converts all files in a netcdf archive to an archive of csv files. The archive will have the same name, except "csv" will be added.

Metadata is included in the file header, but modified slightly for consistency with csv (e.g., commas converted to semi-colons, newlines replaced with "/", etc.)