### PR TITLE
Fix instrument_type being removed if combining same instrument types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-## [0.2] - XXXX-XX-XX
+## [Unreleased] - XXXX-XX-XX
 
 ### Added
 
@@ -22,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AGAGE data specification is now removed. These files should be put in a different repository that calls the functions in this package. See https://github.com/AGAGE-atmosphere/agage-archive-template
 - All files now contain almost the same variables (e.g., instrument_type, even if there is only one instrument)
 
+### Fixed
+
+- ```instrument_type``` variable no longer being removed if multiple instruments of the same type are combined (e.g., multiple Picarros)
+  
 
 ## [0.1] - 2025-01-23
 

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -1249,15 +1249,9 @@ def combine_datasets(network, species, site,
         ds_combined = ds_combined.dropna(dim="time", subset = ["mf"])
 
     # Summarise instrument types in attributes
-    # and remove instrument_type variable if all the same
     instrument_numbers = list(np.unique(ds_combined.instrument_type.values))
-    if len(instrument_numbers) == 1:
-        instrument_name = get_instrument_type(instrument_numbers[0])
-        ds_combined.attrs["instrument_type"] = instrument_name
-        ds_combined = ds_combined.drop_vars("instrument_type")
-    else:
-        instrument_name = get_instrument_type(instrument_numbers)
-        ds_combined.attrs["instrument_type"] = "/".join(instrument_name)
+    instrument_name = get_instrument_type(instrument_numbers)
+    ds_combined.attrs["instrument_type"] = "/".join(instrument_name)
 
     # Update network attribute
     ds_combined.attrs["network"] = "/".join(set(networks))


### PR DESCRIPTION
E.g., if two different Picarros are combined, the instrument_type variable was being removed. Addresses comment in #149, but doesn't close this issue