### PR TITLE
Flexible instrument types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AGAGE data specification is now removed. These files should be put in a different repository that calls the functions in this package. See https://github.com/AGAGE-atmosphere/agage-archive-template
 - All files now contain almost the same variables (e.g., instrument_type, even if there is only one instrument)
 - A release schedule is required for all instruments now. Previously missing from GCMS-Magnum and GCMS-Medusa-flask instruments.
+- The instrument_type values are defined flexibly for each network. Instrument types are taken from the filename of the release schedule csv files.
 
 ### Fixed
 

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -615,4 +615,5 @@ def create_empty_archive(network, archive_suffix_string=""):
 
 
 if __name__ == "__main__":
+
     setup()

--- a/agage_archive/formatting.py
+++ b/agage_archive/formatting.py
@@ -203,6 +203,8 @@ def format_variables(ds,
 
     '''
 
+    network = ds.attrs["network"]
+
     with open_data_file("variables.json", this_repo=True) as f:
         variables = json.load(f)
     
@@ -310,7 +312,7 @@ def format_variables(ds,
 
     # If instrument_type variable is in file, make sure comment is formatted properly
     if "instrument_type" in ds.variables:
-        instrument_number, instrument_number_string = instrument_type_definition()
+        instrument_number, instrument_number_string = instrument_type_definition(network)
         ds.instrument_type.attrs["comment"] = instrument_number_string
 
     # If there are any attribute overrides, apply them
@@ -358,6 +360,7 @@ def format_attributes(ds, instruments = [],
         else:
             raise ValueError("No network specified and none found in dataset attributes. Specify in function call.")
     else:
+        ds.attrs["network"] = network
         network_attrs = network
 
     with open_data_file("attributes.json", network=network_attrs) as f:

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -1425,11 +1425,11 @@ def get_data_read_function(network, instrument):
         function: The data read function for the specified network and instrument.
     """
     
-    with open_data_file("data_read_functions.json", network=network, errors="ignore") as f:
+    with open_data_file("data_read_functions.json", network=network) as f:
         read_functions = json.load(f)
     
     if instrument not in read_functions:
-        error_message = f"Instrument {instrument} not found in NETWORK/data_read_functions.json for network {network}."
+        error_message = f"Instrument {instrument} not found in {network}/data_read_functions.json for network {network}."
         raise ValueError(error_message)
 
     return globals()[read_functions[instrument]]

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -10,7 +10,7 @@ from agage_archive.io import combine_datasets, combine_baseline, \
     output_dataset
 from agage_archive.formatting import format_species
 from agage_archive.convert import monthly_baseline
-from agage_archive.definitions import instrument_number, instrument_selection_text
+from agage_archive.definitions import define_instrument_number, instrument_selection_text
 
 
 def get_error(e):
@@ -52,7 +52,7 @@ def run_timestamp_checks(ds,
         instrument_types = instrument_types[timestamps.duplicated()].unique()
 
         # find instrument name in instrument_number
-        instrument_names = [k for k, v in instrument_number.items() if v in instrument_types]
+        instrument_names = [k for k, v in define_instrument_number(ds.attrs["network"]).items() if v in instrument_types]
         instrument_names = ", ".join(instrument_names)
 
         raise ValueError(f"Duplicate timestamps in {species} at {site}: {duplicated_str} for instrument {instrument_names}")

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -6,8 +6,7 @@ from agage_archive.config import Paths, open_data_file, data_file_list, data_fil
     copy_to_archive, delete_archive, create_empty_archive
 from agage_archive.data_selection import read_release_schedule, read_data_combination, choose_scale_defaults_file
 from agage_archive.io import combine_datasets, combine_baseline, \
-    read_nc, read_baseline, read_ale_gage, read_gcwerks_flask, read_gcms_magnum, \
-    output_dataset
+    read_baseline, output_dataset, get_data_read_function
 from agage_archive.formatting import format_species
 from agage_archive.convert import monthly_baseline
 from agage_archive.definitions import define_instrument_number, instrument_selection_text
@@ -230,22 +229,14 @@ def run_individual_instrument(network, instrument,
     
     rs = read_release_schedule(network, instrument)
 
+    read_function = get_data_read_function(network, instrument)
+    read_baseline_function = read_baseline
+    instrument_out = instrument.lower()
+
     if instrument.upper() == "ALE" or instrument.upper() == "GAGE":
-        read_function = read_ale_gage
-        read_baseline_function = read_baseline
         instrument_out = instrument.lower() + "-gcmd"
     elif instrument.upper() == "GCMS-MEDUSA-FLASK":
-        read_function = read_gcwerks_flask
         read_baseline_function = None
-        instrument_out = "gcms-medusa-flask"
-    elif instrument.upper() == "GCMS-MAGNUM":
-        read_function = read_gcms_magnum
-        read_baseline_function = read_baseline
-        instrument_out = "gcms-magnum"
-    else:
-        read_function = read_nc
-        read_baseline_function = read_baseline
-        instrument_out = instrument.lower()
 
     if species:
         # Process only those species that are in the release schedule

--- a/agage_archive/visualise.py
+++ b/agage_archive/visualise.py
@@ -7,8 +7,6 @@ colours = ["#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#C
 colour_counter = 0
 colour_max = len(colours)
 
-instrument_number, instrument_number_string = instrument_type_definition()
-
 variables = {"mf": "(UNIT)",
             "mf_repeatability": "repeatability (UNIT)",
             "mf_variability": "variability (UNIT)",
@@ -90,6 +88,8 @@ def plot_combined(ds, fig, variable="mf", mode="lines"):
     """
 
     global colour_counter
+
+    instrument_number, instrument_number_string = instrument_type_definition(ds.network)
 
     # Get unique instrument types
     instrument_types = set(ds.instrument_type.values)

--- a/data/agage_test/data_read_functions.json
+++ b/data/agage_test/data_read_functions.json
@@ -1,0 +1,15 @@
+{
+    "ALE": "read_ale_gage",
+    "GAGE": "read_ale_gage",
+    "GCMD": "read_nc",
+    "GCMS-ADS": "read_nc",
+    "GCECD": "read_nc",
+    "GCMS-MteCimone": "read_nc",
+    "GCPDD": "read_nc",
+    "GCMS-Medusa": "read_nc",
+    "GCMS-Medusa-flask": "read_gcwerks_flask",
+    "GCMS-Magnum": "read_gcms_magnum",
+    "Picarro": "read_nc",
+    "LGR": "read_nc",
+    "GCTOFMS": "read_nc"
+}

--- a/notebooks/visualise.ipynb
+++ b/notebooks/visualise.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dashboard(\"agage\", mode=\"markers\")"
+    "dashboard(\"agage_test\", mode=\"markers\")"
    ]
   },
   {
@@ -51,7 +51,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -374,6 +374,7 @@ def test_monthly_baseline():
     ds.attrs["version"] = "test"
     ds.attrs["species"] = "ch4"
     ds.attrs["calibration_scale"] = "TU-87"
+    ds.attrs["network"] = "agage_test"
 
     # Create a sample baseline dataset
     baseline_data = {"baseline": (["time"], np.random.choice([0, 1], size=len(time)))}

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,60 +1,71 @@
 import pytest
 import numpy as np
 
-from agage_archive.definitions import get_instrument_type, get_instrument_number
+from agage_archive.definitions import get_instrument_type, \
+    get_instrument_number, define_instrument_number, \
+    instrument_type_definition
+
+
+def test_define_instrument_number():
+    '''Test define_instrument_number function'''
+
+    network = "agage_test"
+
+    # Test for valid network
+    instrument_number = define_instrument_number(network)
+    assert isinstance(instrument_number, dict)
+    assert "UNDEFINED" in instrument_number
+    assert instrument_number["UNDEFINED"] == -1
+    assert len(instrument_number) > 1
+    for key, value in instrument_number.items():
+        assert isinstance(key, str)
+        assert isinstance(value, int)
+
+
+def test_instrument_type_definition():
+    '''Test instrument_type_definition function'''
+
+    network = "agage_test"
+
+    # Test for valid network
+    instrument_number, instrument_number_string = instrument_type_definition(network)
+    assert isinstance(instrument_number, dict)
+    assert isinstance(instrument_number_string, str)
+    for key, value in instrument_number.items():
+        assert key in instrument_number_string
+        assert str(value) in instrument_number_string
+    
+    # Check that string is the right length from number of commas
+    assert instrument_number_string.count(",") == len(instrument_number) - 1
 
 
 def test_get_instrument_type():
+    '''Test get_instrument_type function'''
     
+    network = "agage_test"
+
     # Test for single instrument number
-    instrument_number = 1
-    instrument_type = get_instrument_type(instrument_number)
-    assert instrument_type == "GAGE"
+    instrument_number = define_instrument_number(network)
 
-    # Test for list of instrument numbers
-    instrument_numbers = [1, 2]
-    instrument_types = get_instrument_type(instrument_numbers)
-    assert instrument_types == ["GAGE", "GCMD"]
-    
-    # Test for invalid input
-    instrument_number = "1"
-    with pytest.raises(ValueError):
-        instrument_type = get_instrument_type(instrument_number)
-
-    # Test for numpy integer
-    instrument_number = np.int64(1)
-    instrument_type = get_instrument_type(instrument_number)
-
-    # Test for numpy integer
-    instrument_number = np.int8(1)
-    instrument_type = get_instrument_type(instrument_number)
-
-    # Test for Medusa flask
-    instrument_number = 5
-    instrument_type = get_instrument_type(instrument_number)
-    assert instrument_type == "GCMS-Medusa-flask"
+    for instrument, number in instrument_number.items():
+        instrument_type = get_instrument_type(number, network)
+        assert isinstance(instrument_type, str)
+        assert instrument_type == instrument
 
 
 def test_get_instrument_number():
     '''Test get_instrument_number function'''
 
-    # Test for single instrument type
-    instrument = "GAGE"
-    instrument_number = get_instrument_number(instrument)
-    assert instrument_number == 1
+    network = "agage_test"
 
-    # Test for invalid input
-    instrument = 1
-    with pytest.raises(ValueError):
-        instrument_number = get_instrument_number(instrument)
+    instrument_number = define_instrument_number(network)
 
-    # Test for partial match
-    instrument = "Picarro-1"
-    instrument_number = get_instrument_number(instrument)
-    assert instrument_number == 8
+    for instrument, number in instrument_number.items():
+        instrument_num = get_instrument_number(instrument, network)
+        assert isinstance(instrument_num, int)
+        assert instrument_num == number
 
-    # Test for no match
-    instrument = "Invalid"
-    with pytest.raises(KeyError):
-        instrument_number = get_instrument_number(instrument)
-
+    # Check for partial match
+    instrument_num = get_instrument_number("Picarro-1", network)
+    assert isinstance(instrument_num, int)
+    assert instrument_num == instrument_number["Picarro"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -416,10 +416,12 @@ def test_define_instrument_type():
 
     instrument = "ALE"
 
+    ds.attrs["network"] = "agage_test"
+
     ds = define_instrument_type(ds, instrument)
 
-    instrument_number, instrument_type_str = instrument_type_definition()
+    instrument_number, instrument_type_str = instrument_type_definition(ds.attrs["network"])
 
     assert ds["instrument_type"].attrs["long_name"] == "Instrument type"
     assert ds["instrument_type"].attrs["comment"] == instrument_type_str
-    assert ds["instrument_type"].values[0] == get_instrument_number(instrument)
+    assert ds["instrument_type"].values[0] == get_instrument_number(instrument, ds.attrs["network"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,7 @@ import json
 from agage_archive.config import Paths, open_data_file
 from agage_archive.io import read_ale_gage, read_nc, combine_datasets, read_nc_path, \
     read_baseline, combine_baseline, output_dataset, read_gcwerks_flask, drop_duplicates, \
-    read_gcms_magnum_file, read_gcms_magnum, define_instrument_type
+    read_gcms_magnum_file, read_gcms_magnum, define_instrument_type, get_data_read_function
 from agage_archive.convert import scale_convert
 from agage_archive.definitions import instrument_type_definition, get_instrument_number
 from agage_archive.definitions import nc4_types
@@ -425,3 +425,16 @@ def test_define_instrument_type():
     assert ds["instrument_type"].attrs["long_name"] == "Instrument type"
     assert ds["instrument_type"].attrs["comment"] == instrument_type_str
     assert ds["instrument_type"].values[0] == get_instrument_number(instrument, ds.attrs["network"])
+
+
+def test_get_data_read_function():
+
+    func = get_data_read_function("agage_test", "GCMD")
+
+    if func.__name__ != "read_nc":
+        raise AssertionError(f"Expected 'read_nc', got '{func.__name__}'")
+
+    func = get_data_read_function("agage_test", "ALE")
+
+    if func.__name__ != "read_ale_gage":
+        raise AssertionError(f"Expected 'read_ale_gage', got '{func.__name__}'")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -430,11 +430,7 @@ def test_define_instrument_type():
 def test_get_data_read_function():
 
     func = get_data_read_function("agage_test", "GCMD")
-
-    if func.__name__ != "read_nc":
-        raise AssertionError(f"Expected 'read_nc', got '{func.__name__}'")
+    assert func.__name__ == "read_nc", f"Expected 'read_nc', got '{func.__name__}'"
 
     func = get_data_read_function("agage_test", "ALE")
-
-    if func.__name__ != "read_ale_gage":
-        raise AssertionError(f"Expected 'read_ale_gage', got '{func.__name__}'")
+    assert func.__name__ == "read_ale_gage", f"Expected 'read_ale_gage', got '{func.__name__}'"


### PR DESCRIPTION
Addresses Issue #149 : Instrument names are taken directly from the release schedule. The mapping between instrument names and read functions is given by the data_read_functions.json file.

This will be a breaking change for all upstream repositories as they will need their own data_read_functions.json