### PR TITLE
Instrument-specific paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All files now contain almost the same variables (e.g., instrument_type, even if there is only one instrument)
 - A release schedule is required for all instruments now. Previously missing from GCMS-Magnum and GCMS-Medusa-flask instruments.
 - The instrument_type values are defined flexibly for each network. Instrument types are taken from the filename of the release schedule csv files.
+- The ```config.yaml``` file now expects a path for every instrument_type defined in the release schedules
 
 ### Fixed
 

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -181,18 +181,7 @@ def setup(network = ""):
                     "gage_path": "gage",
                     "magnum_path": "data-gcms-magnum.tar.gz",
                     "output_path": "output",
-                },
-            "agage":
-                {
-                    "md_path": "data-nc",
-                    "optical_path": "data-optical-nc",
-                    "gcms_path": "data-gcms-nc",
-                    "gcms_flask_path": "data-gcms-flask-nc",
-                    "ale_path": "ale_gage_sio1993/ale",
-                    "gage_path": "ale_gage_sio1993/gage",
-                    "magnum_path": "data-gcms-magnum.tar.gz",
-                    "output_path": "agage-public-archive.zip",
-            }
+                }
         }
     else:
         config["paths"] = {

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -173,24 +173,29 @@ def setup(network = ""):
         config["paths"] = {
             "agage_test":
                 {
-                    "md_path": "data-nc",
-                    "optical_path": "data-optical-nc",
-                    "gcms_path": "data-gcms-nc",
-                    "gcms_flask_path": "data-gcms-flask-nc",
-                    "ale_path": "ale",
-                    "gage_path": "gage",
-                    "magnum_path": "data-gcms-magnum.tar.gz",
-                    "output_path": "output",
+                    "ALE_path": "ale",
+                    "GAGE_path": "gage",
+                    "GCMD_path": "data-nc",
+                    "GCMS-ADS_path": "data-gcms-nc",
+                    "GCECD_path": "data-nc",
+                    "GCMS-MteCimone_path": "data-gcms-nc",
+                    "GCPDD_path": "data-nc",
+                    "GCMS-Medusa_path": "data-gcms-nc",
+                    "GCMS-Medusa-flask_path": {
+                      "cbw": "data-gcms-flask-nc"
+                    },
+                    "GCMS-Magnum_path": "data-gcms-magnum.tar.gz",
+                    "Picarro_path": "data-optical-nc",
+                    "LGR_path": "data-optical-nc",
+                    "GCTOFMS_path": "data-gcms-nc",
+                    "output_path": "output"
                 }
         }
     else:
         config["paths"] = {
             network:
                 {
-                    "md_path": "",
-                    "optical_path": "",
-                    "gcms_path": "",
-                    "gcms_flask_path": "",
+                    "YOUR-INSTRUMENT_path": "",
                     "output_path": "output",
                 }
         }

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -144,7 +144,7 @@ def run_individual_site(site, species, network, instrument,
                 if "individual" in output_subpath:
                     instrument_str = instrument_out
                     if not "instrument_selection_text" in ds.attrs:
-                        raise ValueError(f"Instrument selection text not found in attributes for {species} at {site}")
+                        raise ValueError(f"Instrument selection text not found in attributes")
                     instrument_selection_text_str = ds.attrs["instrument_selection"] #Should default to "Individual instruments"
                 else:
                     instrument_str = ""

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -143,7 +143,7 @@ def run_individual_site(site, species, network, instrument,
 
                 if "individual" in output_subpath:
                     instrument_str = instrument_out
-                    if not "instrument_selection_text" in ds.attrs:
+                    if not "instrument_selection" in ds.attrs:
                         raise ValueError(f"Instrument selection text not found in attributes")
                     instrument_selection_text_str = ds.attrs["instrument_selection"] #Should default to "Individual instruments"
                 else:

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -143,6 +143,8 @@ def run_individual_site(site, species, network, instrument,
 
                 if "individual" in output_subpath:
                     instrument_str = instrument_out
+                    if not "instrument_selection_text" in ds.attrs:
+                        raise ValueError(f"Instrument selection text not found in attributes for {species} at {site}")
                     instrument_selection_text_str = ds.attrs["instrument_selection"] #Should default to "Individual instruments"
                 else:
                     instrument_str = ""

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,11 +2,11 @@
 
 This repository uses two types of version control:
 - git is used to track versions of the code
-- [dvc](https://dvc.org) is used to track versions of the processed data
+- *(Optional)*: [dvc](https://dvc.org) is used to track versions of the processed data
 
 Make sure that you have git installed on your system before you start.
 
-The dvc and dvc-gcloud (Google Cloud plugin) are listed in the requirements file, and can be installed from conda, using the conda-forge channel.
+The dvc and dvc-gcloud (Google Cloud plugin) are listed in the requirements file, and can be installed from conda, using the conda-forge channel. But these are optional, only if you want to use version control with the output files (e.g., for syncing with other users).
 
 ## Initial setup
 
@@ -16,7 +16,7 @@ Alternatively, if avoiding conda, install a virtual environment using ```python 
 Make sure that you have installed the required dependencies (see ```requirements.txt```), which can be done using ```pip install -r requirements.txt```.
 
 Allow the package to be callable using ```pip install --no-build-isolation --no-deps -e . ``` and run ```python agage_archive/config.py```, to set the desired input and output paths.
-If using conda, you can use ```conda develop .``` but note that this functionality is now depricated.
+If using ```conda-build```, you can use ```conda develop .``` from the repository folder.
 
 ### DVC initial setup
 
@@ -86,9 +86,45 @@ dvc push
 git push
 ```
 
-## Copying relevant input files
+## Data paths
 
-You will need to copy over the GCWerks output folders ```data-nc/md```, ```data-nc/gcms``` and ```data-nc/optical``` from whereever you pull the data to your local ```data/archive``` folder (and zip the two folders if not zipped already).
+Paths are specified in a ```config.yaml``` file, a template of which can be created by running: 
+
+```
+python agage_archive/config.py
+```
+
+As of v0.2, each instrument must have its own path specified in the format (case sensitive) ```<instrument>_path: relative/path/to/data```. E.g.:
+
+E.g., the following config is required to run the test suite in this repository:
+
+```
+user:
+  name: My Name, University of Somewhere
+paths:
+  agage_test:
+    ALE_path: ale
+    GAGE_path: gage
+    GCMD_path: data-nc
+    GCMS-ADS_path: data-gcms-nc
+    GCECD_path: data-nc
+    GCMS-MteCimone_path: data-gcms-nc
+    GCPDD_path: data-nc
+    GCMS-Medusa_path: data-gcms-nc
+    GCMS-Medusa-flask_path:
+      cbw: data-gcms-flask-nc
+    GCMS-Magnum_path: data-gcms-magnum.tar.gz
+    Picarro_path: data-optical-nc
+    LGR_path: data-optical-nc
+    GCTOFMS_path: data-gcms-nc
+    output_path: output
+```
+
+*Each of these paths is relative to ```data/<network>```.
+
+## Copying or linking to input files
+
+You will need to copy over, or link to the data folders, relative to ```data/<network>```. E.g., ```data-nc/md```, ```data-nc/gcms``` and ```data-nc/optical``` from whereever you pull the data to your local ```data/archive``` folder (and zip the two folders if not zipped already). These can be folders of zip archives (if zip archives, make sure the ```.zip``` suffix appears in the path specification).
 
 ## Data Specification Files
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -339,7 +339,7 @@ def test_read_gcms_magnum_file():
     species = "HFC-134a"
 
     # Test file is in a subset of the tar archive, stored in a folder with the same name
-    sub_path = paths.magnum_path.split(".tar.gz")[0]
+    sub_path = paths.__getattribute__("GCMS-Magnum_path").split(".tar.gz")[0]
 
     with open_data_file("MHD-ads_1994.dap",
                         network="agage_test",


### PR DESCRIPTION
The ```config.yaml``` file now expects that each instrument has a path. E.g.:

```
GCMS-Medusa_path: data-gcms-nc
```

This allows us to have more fine-grained control over the location of each file.

This is a breaking change.